### PR TITLE
Update Dockerfile for Deb 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian
+FROM debian:8
 RUN apt-get -y update
 RUN apt-get install -y curl supervisor git openssl  build-essential libssl-dev wget
 RUN mkdir -p /var/log/supervisor


### PR DESCRIPTION
Debian 9 isn't building with this set of options; specify debian 8 manually