### PR TITLE
Removing gcs_redirect.py; missing file causes excessive CPU usage

### DIFF
--- a/squid.conf.https_proxy
+++ b/squid.conf.https_proxy
@@ -4866,8 +4866,8 @@ coredump_dir /apps/squid/var/cache
 
 # Add these lines to /etc/squid/squid.conf file.
 # /usr/bin/python should be replaced by the path to python executable if you installed it somewhere else.
-redirect_program /usr/bin/python /apps/squid/gcs_redirect.py
+#redirect_program /usr/bin/python /apps/squid/gcs_redirect.py
 # Number of instances of the above program that should run concurrently.
 # 5 is good enough but you should go for 10 at least. Anything below 5 would not work properly.
-redirect_children 5
+#redirect_children 5
 


### PR DESCRIPTION
As far as I can find, gcs_redirect.py no longer exists. With Squid attempting to use this, it kills CPU usage on small systems, and uses excessive CPU on larger systems. Removing this from squid conf resolves the issue.