### PR TITLE
Shrink Image Size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,14 @@ RUN mkdir -p /var/log/supervisor
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 WORKDIR /apps/
 #RUN wget -O - http://www.squid-cache.org/Versions/v3/3.4/squid-3.4.14.tar.gz | tar zxfv -
-RUN wget -O - http://www.squid-cache.org/Versions/v3/3.5/squid-3.5.27.tar.gz | tar zxfv -
-#RUN cd /apps/squid-3.4.14/ && ./configure --prefix=/apps/squid --enable-icap-client --enable-ssl --with-openssl --enable-ssl-crtd --enable-auth --enable-basic-auth-helpers="NCSA" && make && make install
-RUN CPU=$(( `nproc --all`-1 )) && cd /apps/squid-3.5.27/ && ./configure --prefix=/apps/squid --enable-icap-client --enable-ssl --with-openssl --enable-ssl-crtd --enable-auth --enable-basic-auth-helpers="NCSA" && make -j$CPU && make install
+RUN wget -O - http://www.squid-cache.org/Versions/v3/3.5/squid-3.5.27.tar.gz | tar zxfv - \
+    && CPU=$(( `nproc --all`-1 )) \
+    && cd /apps/squid-3.5.27/ \
+    && ./configure --prefix=/apps/squid --enable-icap-client --enable-ssl --with-openssl --enable-ssl-crtd --enable-auth --enable-basic-auth-helpers="NCSA" \
+    && make -j$CPU \
+    && make install \
+    && cd /apps \
+    && rm -rf /apps/squid-3.5.27
 ADD . /apps/
 
 RUN chown -R nobody /apps/


### PR DESCRIPTION
The main issue was that source files were left behind after building. Due to how docker handles images (snapshots after each command/line which work as "layers") I had to combine the wget, extract, building, and remove "RUN" line into one "layer". I've made this as legible as possible still. This is, last I checked, still docker recommended best practice for image size. Image ID `c75c954c35db` is a fresh build straight from source, which confirms same size as your hub image. Image `0813f7cbdfd0` is a build of https://github.com/salrashid123/squid_proxy/commit/1eb6fa6b3913ad740d0ad0832bf902438718751e and confirms it's a little less than 1/3rd of the size, but still fully functional (in as far as I'm aware/have tested). 

```
core@coreos-s-2vcpu-4gb-sgp1-01 ~/squid_proxy $ docker images
REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
<none>                    <none>              0813f7cbdfd0        12 minutes ago      618MB
<none>                    <none>              c75c954c35db        40 minutes ago      1.98GB
salrashid123/squidproxy   latest              838f9731cb47        2 days ago          1.98GB
```